### PR TITLE
Use drupal namespace when requiring Islandora

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "drupal-module",
     "license": "GPL-3.0-or-later",
     "require": {
-        "islandora/islandora": "^2"
+        "drupal/islandora": "^2"
     },
     "require-dev": {
         "drupal/test_support": "^1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Islandora module dependency to use the new package namespace for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->